### PR TITLE
implement separated eventThread in IOManager

### DIFF
--- a/mordor/iomanager_iocp.h
+++ b/mordor/iomanager_iocp.h
@@ -4,10 +4,12 @@
 #include <map>
 
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/thread/mutex.hpp>
 
 #include "scheduler.h"
+#include "semaphore.h"
 #include "timer.h"
 #include "version.h"
 
@@ -63,7 +65,7 @@ private:
     };
 
 public:
-    IOManager(size_t threads = 1, bool useCaller = true);
+    IOManager(size_t threads = 1, bool useCaller = true, bool enableEventThread = false);
     ~IOManager();
 
     bool stopping();
@@ -85,6 +87,9 @@ protected:
     void tickle();
 
     void onTimerInsertedAtFront() { tickle(); }
+    void workerPoolIdle();
+    void eventLoopIdle();
+    void eventLoop();
 
 private:
     HANDLE m_hCompletionPort;
@@ -94,6 +99,8 @@ private:
     size_t m_pendingEventCount;
     boost::mutex m_mutex;
     std::list<WaitBlock::ptr> m_waitBlocks;
+    Semaphore m_semaphore;
+    boost::scoped_ptr<Thread> m_eventThread;
 };
 
 }

--- a/mordor/iomanager_kqueue.h
+++ b/mordor/iomanager_kqueue.h
@@ -6,8 +6,10 @@
 #include <sys/event.h>
 
 #include <map>
+#include <boost/scoped_ptr.hpp>
 
 #include "scheduler.h"
+#include "semaphore.h"
 #include "timer.h"
 #include "version.h"
 
@@ -40,7 +42,7 @@ private:
     };
 
 public:
-    IOManager(size_t threads = 1, bool useCaller = true);
+    IOManager(size_t threads = 1, bool useCaller = true, bool enableEventThread = false);
     ~IOManager();
 
     bool stopping();
@@ -55,12 +57,17 @@ protected:
     void tickle();
 
     void onTimerInsertedAtFront() { tickle(); }
+    void workerPoolIdle();
+    void eventLoopIdle();
+    void eventLoop();
 
 private:
     int m_kqfd;
     int m_tickleFds[2];
     std::map<std::pair<int, Event>, AsyncEvent> m_pendingEvents;
     boost::mutex m_mutex;
+    Semaphore m_semaphore;
+    boost::scoped_ptr<Thread> m_eventThread;
 };
 
 }


### PR DESCRIPTION
Problem:
- From Scheduler perspective, every working thread should keep busy
  executing fibers until there is no suitable fibers for the thread, and
  then the thread enters idle().
- the principal is fine for WorkerPool but not for IOManager,
  IOManager::idle() does some things that is more important or at least
  as important as executing fibers -- pull I/O event & processTimers
- In a busy system, spectacularily CPU-intensive jobs like
  encryption/decryption or compression/decompression, the
  IOManager::idle() has less frequency to be called() which causes I/O
  event delay and timer expiration delay.

Solution:
- optional have one dedicate thread to check I/O event and expired
  timers, it doesn't execute fibers queued in scheduler. OS thread
  scheduling will ensure this event thread won't be starved for a long
  time, as a result, I/O event and expired timers can enter scheduler as
  soon as possible
- Same change applied to kqueue and iocp version of IOManager

Change-Id: I6337d324d21e25bdfe0af304a6521b555424094f
Signed-off-by: Kevin Cai kevinc@mozy.com
